### PR TITLE
fix(type definitions for typescript): add type to missing prop `cameraId` on camera component

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -173,6 +173,7 @@ export interface GoogleVisionBarcodesDetectedEvent {
 
 export interface RNCameraProps {
   children?: ReactNode | FaCC;
+  cameraId?: string;
 
   autoFocus?: keyof AutoFocus;
   autoFocusPointOfInterest?: Point;


### PR DESCRIPTION
fix #3126 